### PR TITLE
Fix TOC showing top subheader

### DIFF
--- a/static/slate/stylesheets/screen.css.scss
+++ b/static/slate/stylesheets/screen.css.scss
@@ -192,6 +192,7 @@ html, body {
   // Subheaders are the submenus that slide open
   // in the table of contents.
   .tocify-subheader {
+    display: none;
     background-color: $nav-subheader-bg;
     font-size: 12px;
     font-weight: 400;


### PR DESCRIPTION
add missing style `display:none;` to top subheader class