### PR TITLE
move the end tag

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -36,8 +36,8 @@
                         {{ end }}
                     {{ end }}
                 </select>
-            {{ end }}
             </div>
+            {{ end }}
         </div>
     </div>
     <main>


### PR DESCRIPTION
Fix div tag outside of the multilingual template. Hmtl test produces error when it's not multilingual since there is an extra div tag.