### PR TITLE
Fix youtube video script

### DIFF
--- a/static/slate/javascripts/app/_youtube-lazyload.js
+++ b/static/slate/javascripts/app/_youtube-lazyload.js
@@ -18,15 +18,15 @@
         var iframe = document.createElement("iframe");
 
         var iframe_embed = this.dataset.embed.replace(/h.+ed.|[?].+/g,'');
-        var embed_playlist = this.dataset.embed.replace(/h.+ed.+[?]/g,'');
+        var embed_playlist = this.dataset.embed.match(/[?].+/g,'');
 
         iframe.setAttribute("frameborder", "0");
         iframe.setAttribute("allowfullscreen", "");
 
-        if ( embed_playlist === "" ) {
+        if ( embed_playlist === null ) {
           iframe.setAttribute("src", "https://www.youtube.com/embed/"+ iframe_embed + "?rel=0&showinfo=0&autoplay=1");
         } else {
-          iframe.setAttribute("src", "https://www.youtube.com/embed/"+ iframe_embed + "?" + embed_playlist + "&rel=0&showinfo=1&autoplay=1&loop=1");
+          iframe.setAttribute("src", "https://www.youtube.com/embed/"+ iframe_embed + embed_playlist + "&rel=0&showinfo=1&autoplay=1&loop=1");
         }
 
         this.innerHTML = "";


### PR DESCRIPTION
the regex wasn't returning null/empty as it was using `.replace` for videos with playlist and returning the whole embed link.

Now when videos that are not a playlist would return `null` and the `if` statement would work properly.

fixed regex and if statement